### PR TITLE
Make php-fpm server name an env var

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,9 +1,12 @@
 ARG NGINX_VERSION=1.25.1
-
 FROM nginx:${NGINX_VERSION}
 
+ENV PHP_FPM_HOST=php-fpm
+
 COPY conf/fastcgi_params /etc/nginx/fastcgi_params
-COPY conf/nginx.conf /etc/nginx/nginx.conf
+COPY conf/nginx.conf /etc/nginx/nginx.conf.template
+
+COPY docker-entrypoint.sh /
 
 RUN rm /docker-entrypoint.d/* /etc/nginx/conf.d/*.conf && \
-    mkdir -p /code/web
+    chmod +x /docker-entrypoint.sh

--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -25,7 +25,7 @@ http {
     fastcgi_read_timeout 600;
 
     upstream php_fpm_service {
-        server php-fpm:9000;
+        server ${PHP_FPM_HOST}:9000;
     }
 
     server {

--- a/nginx/docker-entrypoint.sh
+++ b/nginx/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/env bash
+
+set -e
+
+envsubst '${PHP_FPM_HOST}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+
+if [[ "$1" == -* ]]; then
+    set -- nginx -g daemon off; "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
This will allow multiple php-fpm+nginx pairs of containers running on the same host.